### PR TITLE
Check if `document` object is exist to understand better if the environment is browser or react native

### DIFF
--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -28,7 +28,7 @@ export function getRequestHeaders(
   }
 
   // in case of browser environments
-  if (typeof window !== 'undefined') {
+  if (typeof window !== 'undefined' && typeof document !== 'undefined') {
     headers['X-Frappe-Site-Name'] = window.location.hostname;
     if (window.csrf_token && window.csrf_token !== '{{ csrf_token }}') {
       headers['X-Frappe-CSRF-Token'] = window.csrf_token;


### PR DESCRIPTION
On the React Native, `window` global is exist but there is no `location` and `hostname` properties on that global, so `typeof window !== 'undefined'` checking is not working in React Native, and `headers['X-Frappe-Site-Name'] = window.location.hostname;` line throws error.

So I added another check as `typeof document !== 'undefined'` that understand better if it is browser or React Native environment