### PR TITLE
feat: add additional 6 document API methods and update README with examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,77 @@ db.deleteDoc('My Custom DocType', 'Test')
   .catch((error) => console.error(error));
 ```
 
+#### Rename a document
+
+To rename a document, pass the name of the DocType, old name, new name, and an optional merge flag to `renameDoc`.
+
+```js
+db.renameDoc('My Custom DocType', 'Old Name', 'New Name')
+  .then((response) => console.log(response.message)) // The message will reflect the updated document name.
+  .catch((error) => console.error(error));
+```
+
+#### Get field values of a document
+
+To retrieve document values, pass the name of the DocType, field names (string or array), filters, and additional parameters to `getValue`.
+
+```js
+/** Get single field value **/
+db.getValue('My Custom DocType', 'Field_Name', [['Filter1', '=', 'Value1'],['Filter2', '=', 'Value2']])
+  .then((doc) => console.log(doc))
+  .catch((error) => console.error(error));
+
+/** Get multiple field values **/
+db.getValue('My Custom DocType', ['Field_Name1', 'Field_Name2'], [['Filter1', '=', 'Value1'],['Filter2', '=', 'Value2']])
+  .then((doc) => console.log(doc))
+  .catch((error) => console.error(error));
+```
+
+#### Set field values of a document
+
+To set field values, pass the name of the DocType, document name, field name (or an object of field-value pairs), and an optional value to `setValue`.
+
+```js
+/** Set value of a single field **/
+db.setValue('My Custom DocType', 'Test', 'Field_Name', 'Value')
+  .then((doc) => console.log(doc))
+  .catch((error) => console.error(error));
+
+/** Set values of multiple fields **/
+db.setValue('My Custom DocType', 'Test', {'Field_Name1':"Value1",'Field_Name2':"Value2"})
+  .then((doc) => console.log(doc))
+  .catch((error) => console.error(error));
+```
+
+#### Get field value from a single doctype
+
+To retrieve a field value from a Single-type doctype, pass the name of the DocType and field name to `getSingleValue`.
+
+```js
+db.getSingleValue('My Custom Single DocType', 'Field_Name')
+  .then((response) => console.log(response.message)) // Message will reflect the value of the field.
+  .catch((error) => console.error(error));
+```
+
+#### Submit a document
+
+To submit a document, pass the document object to `submit`.
+
+```js
+db.submit(doc)
+  .then((doc) => console.log(doc))
+  .catch((error) => console.error(error));
+```
+
+#### Cancel a document
+To cancel a submitted document, pass the name of the DocType and document name to `cancel`.
+
+```js
+db.cancel('My Custom DocType', 'Test')
+  .then((doc) => console.log(doc))
+  .catch((error) => console.error(error));
+```
+
 ## Usage with Typescript
 
 The library supports Typescript out of the box.

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -357,4 +357,34 @@ export class FrappeDB {
       });
   }
 
+  /**
+   * Gets the field value from the database for a specific single doctype.
+   * @param {string} doctype Name of the doctype
+   * @param {string} field Name of the field 
+   * @returns Promise which resolves a value of the field 
+   */
+  async getSingleValue<T = any>(
+    doctype: string,
+    field: string,
+  ): Promise<T> {
+
+    const params: any = {
+      doctype,
+      field,
+    };
+
+    return this.axios
+      .get('/api/method/frappe.client.get_single_value', { params })
+      .then((res) => res.data)
+      .catch((error) => {
+        throw {
+          ...error.response.data,
+          httpStatus: error.response.status,
+          httpStatusText: error.response.statusText,
+          message: 'There was an error while getting the value of single doctype.',
+          exception: error.response.data.exception ?? error.response.data.exc_type ?? '',
+        } as Error;
+      });
+  }
+
 }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -224,4 +224,38 @@ export class FrappeDB {
 
     return {} as FrappeDoc<T>;
   }
+  
+  /**
+   * Renames a document from the database
+   * @param {string} doctype Name of the doctype
+   * @param {string} oldname Current name of the document
+   * @param {string} newname The new name that will replace the `oldname`
+   * @param {boolean} merge  Merges the old document into the new one if a document with `newname` already exists.
+   * @returns Promise which resolves with the updated document name
+   */
+  async renameDoc<T = any>(
+    doctype: string,
+    oldname: string | null,
+    newname: string | null,
+    merge: boolean = false,
+  ): Promise<FrappeDoc<T>> {
+    return this.axios
+      .post('/api/method/frappe.client.rename_doc', {
+        doctype,
+        old_name: oldname,
+        new_name: newname,
+        merge: merge,
+      })
+      .then((res) => res.data)
+      .catch((error) => {
+        throw {
+          ...error.response.data,
+          httpStatus: error.response.status,
+          httpStatusText: error.response.statusText,
+          message: error.response.data.message ?? 'There was an error while creating the document.',
+          exception: error.response.data.exception ?? error.response.data.exc_type ?? '',
+        };
+      });
+  }
+
 }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -319,4 +319,42 @@ export class FrappeDB {
       });
   }
 
+  /**
+   * Sets the field values in the database for the specified doctype.
+   * @param {string} doctype Name of the doctype
+   * @param {string} name Name of the document
+   * @param {string | object} fieldname Fieldname(s) whose value(s) need to be set.
+   * @param {any} value Value to be set in the fieldname if fieldname
+   * @returns Promise which resolves a updated docoument
+   */
+  async setValue<T = any>(
+    doctype: string,
+    name: string,
+    fieldname: string | object,
+    value?: any,
+  ): Promise<FrappeDoc<T>> {
+
+    if(fieldname !== null && typeof fieldname === 'object' && !Array.isArray(fieldname)) {
+      value = undefined
+    }
+
+    return this.axios
+      .post('/api/method/frappe.client.set_value', { 
+        doctype,
+        name,
+        fieldname,
+        value
+       })
+      .then((res) => {console.log(res.data.message); return res.data.message })
+      .catch((error) => {
+        throw {
+          ...error.response.data,
+          httpStatus: error.response.status,
+          httpStatusText: error.response.statusText,
+          message: 'There was an error while setting the value.',
+          exception: error.response.data.exception ?? error.response.data.exc_type ?? '',
+        } as Error;
+      });
+  }
+
 }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -263,7 +263,7 @@ export class FrappeDB {
   }
 
   /**
-   * Gets value of document from the database for a particular doctype with the given fieldnames and filters
+   * Retrieves a document's value from the database for a specific doctype using the provided field names and filters.
    * @param {string} doctype Name of the doctype
    * @param {FieldName} [fieldname] - Fields to be returned (default `name`)
    * @param {Filter[]} [filters] Filters to be applied in the get query
@@ -320,7 +320,7 @@ export class FrappeDB {
    * @param {string} doctype Name of the doctype
    * @param {string} name Name of the document
    * @param {string | object} fieldname Fieldname(s) whose value(s) need to be set.
-   * @param {any} value Value to be set in the fieldname if fieldname
+   * @param {any} value Value to be set in fieldname when updating a single field or if `fieldname` is a string.
    * @returns Promise which resolves an updated docoument
    */
   async setValue<T = any>(
@@ -353,10 +353,10 @@ export class FrappeDB {
   }
 
   /**
-   * Gets the field value from the database for a specific single doctype.
+   * Retrieves the field value from the database for a specific single doctype.
    * @param {string} doctype Name of the doctype
    * @param {string} field Name of the field
-   * @returns Promise which resolves a value of the field
+   * @returns Promise that resolves to the field's value.
    */
   async getSingleValue<T = any>(doctype: string, field: string): Promise<T> {
     const params: any = {
@@ -381,7 +381,7 @@ export class FrappeDB {
   /**
    * Submit a document.
    * @param {object} doc Document to be submitted
-   * @returns Promise which resolves a submitted document
+   * @returns Promise that resolves to a submitted document.
    */
   async submit<T = any>(doc: object): Promise<T> {
     return this.axios
@@ -402,7 +402,7 @@ export class FrappeDB {
    * Cancel a document.
    * @param {string} doctype Name of the doctype
    * @param {string} name Name of the document to be cancelled
-   * @returns Promise which resolves a cancelled document
+   * @returns Promise that resolves to a canceled document.
    */
   async cancel<T = any>(doctype: string, name: string): Promise<FrappeDoc<T>> {
     return this.axios

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -6,6 +6,7 @@ type FilterVar<T> = keyof T | (string & Record<never, never>);
 type SingleValueFilter<T> = [FilterVar<T>, SingleValueFilterOperator, Value];
 type MultiValueFilter<T> = [FilterVar<T>, MultiValueFilterOperator, Value[]];
 export type Filter<T = FrappeDoc<{}>> = SingleValueFilter<T> | MultiValueFilter<T>;
+export type FieldName = Array<string> | string;
 
 export type FrappeDoc<T> = T & {
   /** User who created the document */


### PR DESCRIPTION
## Summary
This PR adds six new API methods to the `frappe-js-sdk` for interacting with Frappe documents. Additionally, the README has been updated to include usage examples for these methods.

## Changes Introduced
- Added the following API methods:
  1. `getValue` - Fetch single or multiple field values from a document based on filters.
  2. `setValue` - Set single or multiple field values in a document.
  3. `renameDoc` - Rename an existing document.
  4. `getSingleValue` - Retrieve a field value from a Single Doctype.
  5. `submit` - Submit a document.
  6. `cancel` - Cancel a document.
 
- Updated `db/types`
  - Add FieldName type to support new API methods.

- Updated the README with:
  - Code examples for the newly added methods.
  - Parameter descriptions and expected outputs.

## How to Test
- Call each method with appropriate parameters and ensure they return expected results.
- Verify that the README examples execute correctly without errors.


## Notes
- These changes enhance the SDK’s usability by providing essential document operations.
- Ensure that backend permissions allow necessary CRUD operations for testing.

@nikkothari22 
